### PR TITLE
Consume message immediately to avoid timeout

### DIFF
--- a/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
+++ b/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
@@ -17,7 +17,7 @@
 package com.pennsieve.streaming.query
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Source, Sink}
 import com.pennsieve.service.utilities.ContextLogger
 import com.pennsieve.streaming.query.TimeSeriesQueryUtils._
 import com.pennsieve.streaming.server.Montage
@@ -200,6 +200,9 @@ class TimeSeriesQueryRawHttp(
     *         should be used along with the wsClient.close method to
     *         release all resources
     */
-  private def requestData(location: String): Future[Source[Double, Any]] =
-    wsClient.getDataSource(location)
+  def requestData(location: String): Future[Source[Double, Any]] =
+    wsClient.getDataSource(location).map { source =>
+      // Trigger subscription to avoid timeout, discard in a side channel
+      source.alsoTo(Sink.ignore)
+  }
 }


### PR DESCRIPTION
Attempt to solve `java.util.concurrent.TimeoutException: Response entity was not subscribed after 1 second. Make sure to read the response entity body or call `discardBytes()` on it. GET /N:channel:ff4b6df7-89cf-4f26-a35b-2f7551f159a9_946814198000000_946814460142000.bin.gz Empty -> 200 OK Default(171889 bytes)` error

This error seems to be common. See [Akka docs](https://doc.akka.io/libraries/akka-http/current/implications-of-streaming-http-entity.html#integrating-with-akka-streams).

Modified to send to a side channel with `alsoTo`which subscribes  immediately to stop the timeout, but then ignores it on that side channel. Then the rest of the code can continue as normal without eagerly downloading to memory.