### PR TITLE
Immediately acknowledge akka stream

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 timeseries {
   s3-base-url = ${?CLOUDFRONT_URL}
   s3-host = ${?CLOUDFRONT_HOST}
+  s3-port = 80
 
   parallelism = 8
   parallelism = ${?PARALLELISM}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,7 +1,8 @@
 timeseries {
   s3-base-url = ${?CLOUDFRONT_URL}
   s3-host = ${?CLOUDFRONT_HOST}
-  s3-port = 80
+  s3-port = 443
+  s3-use-ssl = true
 
   parallelism = 8
   parallelism = ${?PARALLELISM}

--- a/src/main/resources/test.conf
+++ b/src/main/resources/test.conf
@@ -1,5 +1,6 @@
 timeseries {
   s3-host = "n/a"
+  s3-port = "n/a"
   s3-base-url = "src/test/resources/"
 
   parallelism = 8

--- a/src/main/resources/test.conf
+++ b/src/main/resources/test.conf
@@ -1,6 +1,7 @@
 timeseries {
   s3-host = "n/a"
   s3-port = "n/a"
+  s3-use-ssl = "n/a"
   s3-base-url = "src/test/resources/"
 
   parallelism = 8

--- a/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
+++ b/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
@@ -200,9 +200,6 @@ class TimeSeriesQueryRawHttp(
     *         should be used along with the wsClient.close method to
     *         release all resources
     */
-  def requestData(location: String): Future[Source[Double, Any]] =
-    wsClient.getDataSource(location).map { source =>
-      // Trigger subscription to avoid timeout, discard in a side channel
-      source.alsoTo(Sink.ignore)
-  }
+  private def requestData(location: String): Future[Source[Double, Any]] =
+      wsClient.getDataSource(location)
 }

--- a/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
+++ b/src/main/scala/com/pennsieve/streaming/query/TimeSeriesQueryRawHttp.scala
@@ -17,7 +17,7 @@
 package com.pennsieve.streaming.query
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Source, Sink}
+import akka.stream.scaladsl.{ Sink, Source }
 import com.pennsieve.service.utilities.ContextLogger
 import com.pennsieve.streaming.query.TimeSeriesQueryUtils._
 import com.pennsieve.streaming.server.Montage
@@ -201,5 +201,5 @@ class TimeSeriesQueryRawHttp(
     *         release all resources
     */
   private def requestData(location: String): Future[Source[Double, Any]] =
-      wsClient.getDataSource(location)
+    wsClient.getDataSource(location)
 }

--- a/src/main/scala/com/pennsieve/streaming/query/WsClient.scala
+++ b/src/main/scala/com/pennsieve/streaming/query/WsClient.scala
@@ -151,15 +151,13 @@ class S3WsClient(
 ) extends WsClient {
 
   private val s3host = appconfig.getString("timeseries.s3-host")
+  private val s3Port = appconfig.getInt("timeseries.s3-port")
   private val QueueSize = appconfig.getInt("timeseries.request-queue-size")
 
   // This idea came initially from this blog post:
   // http://kazuhiro.github.io/scala/akka/akka-http/akka-streams/2016/01/31/connection-pooling-with-akka-http-and-source-queue.html
   private val poolClientFlow =
-    if (s3host.startsWith("localhost"))
-      Http().cachedHostConnectionPool[Promise[HttpResponse]](host = s3host, port = 8081)
-    else
-      Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](host = s3host)
+    Http().cachedHostConnectionPool[Promise[HttpResponse]](host = s3host, port = s3Port)
 
   private val queue =
     Source

--- a/src/main/scala/com/pennsieve/streaming/query/WsClient.scala
+++ b/src/main/scala/com/pennsieve/streaming/query/WsClient.scala
@@ -152,12 +152,15 @@ class S3WsClient(
 
   private val s3host = appconfig.getString("timeseries.s3-host")
   private val s3Port = appconfig.getInt("timeseries.s3-port")
+  private val s3UseSsl = appconfig.getBoolean("timeseries.s3-use-ssl")
   private val QueueSize = appconfig.getInt("timeseries.request-queue-size")
 
   // This idea came initially from this blog post:
   // http://kazuhiro.github.io/scala/akka/akka-http/akka-streams/2016/01/31/connection-pooling-with-akka-http-and-source-queue.html
   private val poolClientFlow =
-    Http().cachedHostConnectionPool[Promise[HttpResponse]](host = s3host, port = s3Port)
+    if (s3UseSsl)
+      Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](host = s3host, port = s3Port)
+    else Http().cachedHostConnectionPool[Promise[HttpResponse]](host = s3host, port = s3Port)
 
   private val queue =
     Source

--- a/src/test/scala/com/pennsieve/streaming/WsClient.scala
+++ b/src/test/scala/com/pennsieve/streaming/WsClient.scala
@@ -102,7 +102,7 @@ class WsClientSpec
     val dataFut = sourceFut.flatMap(_.runWith(Sink.seq))
     val result = Await.result(dataFut, 5.seconds)
 
-    println(s"got stream with ${result.length} items: $result")
+    println(s"got stream with ${result.length} items")
     result should not be empty
     println(s"Streamed ${result.length} values from $url")
   }
@@ -116,7 +116,7 @@ class WsClientSpec
     val dataFut = sourceFut.flatMap(_.runWith(Sink.seq))
     val result = Await.result(dataFut, 5.seconds)
 
-    println(s"got stream with ${result.length} items: $result")
+    println(s"got stream with ${result.length} items")
     result should not be empty
     println(s"Streamed ${result.length} values from $url")
   }

--- a/src/test/scala/com/pennsieve/streaming/WsClient.scala
+++ b/src/test/scala/com/pennsieve/streaming/WsClient.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pennsieve.streaming
 
 import akka.actor.ActorSystem

--- a/src/test/scala/com/pennsieve/streaming/WsClient.scala
+++ b/src/test/scala/com/pennsieve/streaming/WsClient.scala
@@ -1,0 +1,108 @@
+package com.pennsieve.streaming
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ `Content-Encoding`, HttpEncodings }
+import akka.http.scaladsl.server.Directives._
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.ByteString
+import com.pennsieve.service.utilities.ContextLogger
+import com.pennsieve.streaming.query.{ S3WsClient, WsClient }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ BeforeAndAfterAll, FlatSpec, Matchers }
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+import com.pennsieve.streaming.query.LocalFilesystemWsClient
+
+/**
+  * Tests the S3WsClient behavior when retrieving a gzipped stream.
+  * Simulates delayed consumption to verify that the stream is correctly materialized.
+  */
+class WsClientSpec
+    extends FlatSpec
+    with Matchers
+    with AkkaImplicits
+    with BeforeAndAfterAll
+    with TestConfig {
+
+  implicit val log: ContextLogger = new ContextLogger()
+  implicit val mat: Materializer = Materializer(system)
+
+  private var bindingFuture: Future[Http.ServerBinding] = _
+  private val port = 8081
+
+  val fakeConfig = ConfigFactory.parseString("""
+        timeseries.s3-host = "localhost"
+        timeseries.s3-port = 8081
+        timeseries.request-queue-size = 10
+    """)
+
+  val wsClient = new S3WsClient(fakeConfig)
+  val url = s"http://localhost:8081/test-data"
+
+  override def beforeAll(): Unit = {
+    val testData = (1 to 100000).map(_.toString)
+    val gzippedContent = gzippedBytes(testData)
+
+    val testRoute =
+      path("test-data") {
+        get {
+          complete(
+            HttpResponse(
+              entity = HttpEntity(ContentTypes.`application/octet-stream`, gzippedContent)
+            ).withHeaders(`Content-Encoding`(HttpEncodings.gzip))
+          )
+        }
+      }
+
+    bindingFuture = Http().bindAndHandle(testRoute, "localhost", port)
+    Await.result(bindingFuture, 3.seconds)
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(bindingFuture.flatMap(_.unbind()), 3.seconds)
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  private def gzippedBytes(lines: Seq[String]): ByteString = {
+    val out = new ByteArrayOutputStream()
+    val gzip = new GZIPOutputStream(out)
+    lines.foreach(line => gzip.write((line + "\n").getBytes("UTF-8")))
+    gzip.close()
+    ByteString(out.toByteArray)
+  }
+
+  "getDataSource" should "not fail with TimeoutException after a delay" in {
+
+    val sourceFut = wsClient.getDataSource(url)
+
+    Thread.sleep(2000)
+
+    val dataFut = sourceFut.flatMap(_.runWith(Sink.seq))
+    val result = Await.result(dataFut, 5.seconds)
+
+    println(s"got stream with ${result.length} items: $result")
+    result should not be empty
+    println(s"Streamed ${result.length} values from $url")
+  }
+
+  "getEventSource" should "not fail with TimeoutException after a delay" in {
+
+    val sourceFut = wsClient.getEventSource(url)
+
+    Thread.sleep(2000)
+
+    val dataFut = sourceFut.flatMap(_.runWith(Sink.seq))
+    val result = Await.result(dataFut, 5.seconds)
+
+    println(s"got stream with ${result.length} items: $result")
+    result should not be empty
+    println(s"Streamed ${result.length} values from $url")
+  }
+
+}

--- a/src/test/scala/com/pennsieve/streaming/WsClientSpec.scala
+++ b/src/test/scala/com/pennsieve/streaming/WsClientSpec.scala
@@ -75,6 +75,7 @@ class WsClientSpec
     val port = Await.result(bindingFuture, 3.seconds).localAddress.getPort
     fakeConfig = ConfigFactory
       .empty()
+      .withValue("timeseries.s3-use-ssl", ConfigValueFactory.fromAnyRef(false))
       .withValue("timeseries.s3-host", ConfigValueFactory.fromAnyRef("localhost"))
       .withValue("timeseries.s3-port", ConfigValueFactory.fromAnyRef(port))
       .withValue("timeseries.request-queue-size", ConfigValueFactory.fromAnyRef(10))


### PR DESCRIPTION
Immediately acknowledge akka streams in `getDataSource` and `getEventSource`. Previous attempt using Sink.ignore wasn't the right way forward.

Also added a test to recreate the  `Response entity was not subscribed after 1 second` message, see that it failed and then see that the new code fixed it. See video below

https://github.com/user-attachments/assets/ba045101-6aab-464d-a904-f35dd7c48aac