### PR TITLE
change montage delimiter to prevent error on '-' --> use '<->' instead

### DIFF
--- a/src/main/scala/com/pennsieve/streaming/server/Montage.scala
+++ b/src/main/scala/com/pennsieve/streaming/server/Montage.scala
@@ -25,7 +25,7 @@ import scala.collection.concurrent
 object Montage {
 
   // The separator between channel names for all montages
-  private val SEPARATOR = '-'
+  private val SEPARATOR = "<->"
 
   /** A complete list of all channels required for */
   def allMontageChannelNames: Set[String] =

--- a/src/main/scala/com/pennsieve/streaming/server/TimeSeriesFlow.scala
+++ b/src/main/scala/com/pennsieve/streaming/server/TimeSeriesFlow.scala
@@ -298,7 +298,7 @@ class TimeSeriesFlow(
         packageMontages.remove(packageId)
       }
       case MontageRequest(packageId, MontageType.CustomMontage(), montageMap) => {
-        log.noContext.error("Getting custom Montage " + montageMap.get)
+        log.noContext.info("Getting custom Montage " + montageMap.get)
         val customMontage = MontageType.CustomMontage()
         customMontage.updatePairs(montageMap.get) // Set the custom pairs
         packageMontages.put(packageId, customMontage)

--- a/src/test/scala/com/pennsieve/streaming/MontageSpec.scala
+++ b/src/test/scala/com/pennsieve/streaming/MontageSpec.scala
@@ -94,7 +94,7 @@ class MontageSpec extends FlatSpec with Matchers {
   }
 
   "getMontagePair" should "split channel names if is a montage" in {
-    val channelName = "montage-channel"
+    val channelName = "montage<->channel"
 
     val pair =
       Montage.getMontagePair(channelName, MontageType.ReferentialVsCz)
@@ -103,7 +103,7 @@ class MontageSpec extends FlatSpec with Matchers {
   }
 
   "getMontagePair" should "fail to split invalid channel names if there is a montage" in {
-    val channelName = "invalid-montage-channel"
+    val channelName = "invalid<->montage<->channel"
 
     val pair =
       Montage.getMontagePair(channelName, MontageType.ReferentialVsCz)
@@ -149,7 +149,7 @@ class MontageSpec extends FlatSpec with Matchers {
   }
 
   "buildMontage" should "fail with invalid channel names if is a montage" in {
-    val invalidNames = List("tricky-name", "really-invalid-name")
+    val invalidNames = List("tricky<->name", "really<->invalid<->name")
 
     val channelMap: Map[String, Channel] =
       invalidNames.map { channelName =>

--- a/src/test/scala/com/pennsieve/streaming/TimeSeriesFlowSpec.scala
+++ b/src/test/scala/com/pennsieve/streaming/TimeSeriesFlowSpec.scala
@@ -343,7 +343,7 @@ class TimeSeriesFlowSpec
   "montaged channels" should "be combined into a single data stream" in { implicit dbSession =>
     val leadChannelId = "Fp1_id"
 
-    val montageName = "Fp1-Cz"
+    val montageName = "Fp1<->Cz"
     val montageSession = "montage_session"
 
     val request = TextMessage(

--- a/src/test/scala/com/pennsieve/streaming/server/WebServerSpec.scala
+++ b/src/test/scala/com/pennsieve/streaming/server/WebServerSpec.scala
@@ -19,20 +19,20 @@ package com.pennsieve.streaming.server
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.Unauthorized
-import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
-import akka.http.scaladsl.model.ws.{BinaryMessage, TextMessage}
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest, WSProbe}
+import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
+import akka.http.scaladsl.model.ws.{ BinaryMessage, TextMessage }
+import akka.http.scaladsl.testkit.{ RouteTestTimeout, ScalatestRouteTest, WSProbe }
 import com.pennsieve.auth.middleware.Jwt.Claim
 import com.pennsieve.auth.middleware.Jwt.Role.RoleIdentifier
-import com.pennsieve.auth.middleware.{DatasetId, Jwt, OrganizationId, UserClaim, UserId}
+import com.pennsieve.auth.middleware.{ DatasetId, Jwt, OrganizationId, UserClaim, UserId }
 import com.pennsieve.core.utilities.JwtAuthenticator._
 import com.pennsieve.models.Role
 import com.pennsieve.service.utilities.ContextLogger
 import com.pennsieve.streaming.query.LocalFilesystemWsClient
 import com.pennsieve.streaming.server.TSJsonSupport._
-import com.pennsieve.streaming.{SessionGenerator, TestConfig, TestDatabase}
+import com.pennsieve.streaming.{ SessionGenerator, TestConfig, TestDatabase }
 import com.pennsieve.streaming.TimeSeriesMessage
-import org.scalatest.{Inspectors, Matchers}
+import org.scalatest.{ Inspectors, Matchers }
 import org.scalatest.fixture.WordSpec
 import shapeless.syntax.inject._
 import spray.json._
@@ -504,7 +504,8 @@ class WebServerSpec
 
         virtualChannelsList should contain theSameElementsAs expected
 
-        val virtualChannelsToRequest = List(VirtualChannel(id = "F3_id", name = "F3"),VirtualChannel(id = "A1_id", name = "A1"))
+        val virtualChannelsToRequest =
+          List(VirtualChannel(id = "F3_id", name = "F3"), VirtualChannel(id = "A1_id", name = "A1"))
 
         val timeSeriesRequest = TextMessage(
           TimeSeriesRequest(


### PR DESCRIPTION
Previous version would fail montaging channels that have '-' in the channel names. However, this is not uncommon.
We updated the code to indicate <-> as the montage channel delimiter which will be more tolerant of names.
